### PR TITLE
Added reconnection retries on timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbstream-mongo",
-  "version": "1.3.11",
+  "version": "1.4.0",
   "description": "Mongo DB access layer compatible with the Database Stream API",
   "main": "mongo.js",
   "scripts": {


### PR DESCRIPTION
As discussed this, this adds a simple reconnect mechanism on connection timeout.

Tests added, and version bumped to `1.4.0` as per semantic versioning rules - the retry mechanism was added in a backwards-compatible manner (default number of retries is 1 - a single attempt).