### PR TITLE
workaround for current mongodb version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "test": "node_modules/mocha/bin/mocha",
     "postinstall": "npm run fix-dependencies",
-    "fix-dependencies": "cp node_modules/bson/browser_build/* node_modules/bson/build/Release/",
- 
+    "fix-dependencies": "cp node_modules/bson/browser_build/* node_modules/bson/build/Release/"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Mongo DB access layer compatible with the Database Stream API",
   "main": "mongo.js",
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha"
+    "test": "node_modules/mocha/bin/mocha",
+    "postinstall": "npm run fix-dependencies",
+    "fix-dependencies": "cp node_modules/bson/browser_build/* node_modules/bson/build/Release/",
+ 
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
temporary workaround for current mongodb version dependency to avoid the following error:
```
{ Error: Cannot find module '../build/Release/bson'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/app/color/node_modules/dbstream-mongo/node_modules/bson/ext/index.js:15:10)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/app/color/node_modules/dbstream-mongo/node_modules/bson/lib/bson/index.js:3:24)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/app/color/node_modules/dbstream-mongo/node_modules/mongodb/lib/mongodb/index.js:2:22)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19) code: 'MODULE_NOT_FOUND' }
```