### PR TITLE
Mongodb version upgrade

### DIFF
--- a/mongo.js
+++ b/mongo.js
@@ -7,6 +7,8 @@ var util = require( "util" );
 module.exports.mongodb = mongodb
 module.exports.ObjectID = mongodb.ObjectID
 
+const CLOSE_TIME_OUT = 10 * 60 * 1000 // 10 minutes
+
 util.inherits( Cursor, db.Cursor );
 function Cursor( conn ) {
     Cursor.super_.call( this );
@@ -137,10 +139,16 @@ function closeDb( url ) {
         return;
     }
 
+    let closeTimeOut = CLOSE_TIME_OUT
+    const timeOut = options._closeTimeOut
+    if (timeOut && timeOut >= 0) {
+        closeTimeOut = timeOut
+    }
+
     connections[ url ].closeTimeout = setTimeout( function () {
         connections[ url ].db.close()
         delete connections[ url ];
-    }, 10 * 60 * 1000 );
+    }, closeTimeOut );
 }
 
 function getDb ( url, options, callback ) {

--- a/mongo.js
+++ b/mongo.js
@@ -26,16 +26,12 @@ Cursor.prototype._save = function ( object, callback ) {
             delete serialized.id;
         }
 
-        let isUpdate = false
-
         if ( !serialized._id ) {
             collection.insertOne( serialized, ondone )
         } else {
-            isUpdate = true
             const filter = { "_id": serialized._id }
-            const update = { $set: serialized }
             const options = { upsert: true }
-            collection.updateOne( filter, update, options, ondone );
+            collection.replaceOne( filter,  serialized, options, ondone );
         }
 
         function ondone ( err, result ) {
@@ -44,11 +40,9 @@ Cursor.prototype._save = function ( object, callback ) {
             if ( typeof result == "object" ) {
                 if ( result.ops && result.ops.length > 0 ) {
                     result = result.ops[0]
-                    result.id = fromObjectID( result._id );
-                    delete result._id;
-                } else if ( isUpdate ) {
-                    result = {}
                 }
+                result.id = fromObjectID( result._id );
+                delete result._id;
                 replace( object, result );
             }
             callback();

--- a/mongo.js
+++ b/mongo.js
@@ -26,7 +26,7 @@ Cursor.prototype._save = function ( object, callback ) {
             delete serialized.id;
         }
 
-        collection.insert( serialized, ondone );
+        collection.save( serialized, ondone );
 
         function ondone ( err, result ) {
             conn.done();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dbstream-mongo",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "description": "Mongo DB access layer compatible with the Database Stream API",
   "main": "mongo.js",
   "scripts": {
@@ -31,6 +31,6 @@
   "dependencies": {
     "dbstream": "^1.0.1",
     "extend": "^3.0.0",
-    "mongodb": "^1.4.7"
+    "mongodb": "^3.1.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -132,7 +132,7 @@ function mock_connect ( url, options, callback ) {
 function mock_collection() {
     var data = [];
     return {
-        insert: function ( obj, callback ) {
+        save: function ( obj, callback ) {
             obj = copy( obj );
             if ( !obj._id ) {
                 obj._id = ( Math.random() * 1e17 ).toString( 36 );

--- a/test.js
+++ b/test.js
@@ -8,7 +8,7 @@ var sift = require( "sift" );
 
 var connect = mongodb.MongoClient.connect;
 
-var options = { collection: "test" };
+var options = { collection: "test", _closeTimeOut: 1 };
 var addr = "mongodb://127.0.0.1:27017/test1";
 
 describe( "Mongo", function() {
@@ -25,8 +25,10 @@ describe( "Mongo", function() {
 
     it( "Supports multiple collections", function ( done ) {
         var addr = "mongodb://127.0.0.1:27017/test2";
-        var conn1 = db.connect( addr, { collection: "test2" } )
-        var conn2 = db.connect( addr, { collection: "test3" } )
+        var options1 = { collection: "test2" , _closeTimeOut: 1 }
+        var options2 = { collection: "test3" , _closeTimeOut: 1 }
+        var conn1 = db.connect( addr, options1)
+        var conn2 = db.connect( addr, options2)
 
         var data = [];
         new conn1.Cursor()
@@ -86,12 +88,12 @@ describe( "Mongo", function() {
 
     // ensure that all the connections were closed
     after( function ( done ) {
-        this.timeout( 15000 );
+        this.timeout( 15 * 1000 );
         setTimeout( function () {
             var dbkeys = Object.keys( dbs );
             assert.equal( dbkeys.length, 0, "No all connections were closed: " + dbkeys )
             done();
-        }, 11000 );
+        }, 11 * 1000 );
     })
 
 });

--- a/test.js
+++ b/test.js
@@ -144,8 +144,8 @@ function mock_collection() {
                 })
             });
         },
-        updateOne: function ( filter, update, options, callback ) {
-            this.insertOne( update.$set, callback )
+        replaceOne: function ( filter, obj, options, callback ) {
+            this.insertOne( obj, callback )
         },
         remove: function( query, callback ) {
             // console.log( query, data );

--- a/test.js
+++ b/test.js
@@ -132,7 +132,7 @@ function mock_connect ( url, options, callback ) {
 function mock_collection() {
     var data = [];
     return {
-        save: function ( obj, callback ) {
+        insertOne: function ( obj, callback ) {
             obj = copy( obj );
             if ( !obj._id ) {
                 obj._id = ( Math.random() * 1e17 ).toString( 36 );
@@ -143,6 +143,9 @@ function mock_collection() {
                     callback( null, ( is_update ) ? 1 : copy( obj ) );
                 })
             });
+        },
+        updateOne: function ( filter, update, options, callback ) {
+            this.insertOne( update.$set, callback )
         },
         remove: function( query, callback ) {
             // console.log( query, data );


### PR DESCRIPTION
## Description:
* Upgrade MongoDB driver to the latest release 3.1:
1. Change the connection from getDB to getClient -> In the previous mongodb version the database object was an argument to the connect callback.
According to the [changelog](https://github.com/mongodb/node-mongodb-native/blob/3.0/CHANGES_3.0.0.md) for version 3 the client object containing the database object instead.

2. Delete from options redundant parameters that throw warnings when trying to connect.
Example : `WARN the options [maxRetries] is not supported`

3. Use both `collection.insertOne` and `collection.updateOne` to keep the same functionality as `save.collection` who is deprecated.

* Some tests failed due to the fact that not all the connection were closed.
The default timeout is set to 10 minutes while the timeout in the after function for the test is only 15 seconds. 
Added `_closeTimeOut` parameter to options to change the default timeout to expand options functionality and to fix the tests.